### PR TITLE
Fix: Allow 'null' origin in CORS for packaged EXE

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -32,10 +32,11 @@ class Settings(BaseSettings):
     # API配置
     api_prefix: str = "/api/v1"
     cors_origins: list = [
-        "http://localhost:3000",
-        "http://localhost:3002",
+        "http://localhost:3000",  # Standard frontend dev port
+        "http://localhost:3002",  # Alternative frontend dev port
         "http://127.0.0.1:3000",
-        "http://127.0.0.1:3002"
+        "http://127.0.0.1:3002",
+        "null"  # Allow requests from 'file://' origins
     ]
     
     # 日志配置


### PR DESCRIPTION
The frontend, when built and run from your local filesystem (file://), has an origin of 'null'. The backend's CORS policy did not include 'null', preventing the frontend from communicating with the backend when the application is packaged as an EXE and the frontend is opened directly via index.html.

This commit adds 'null' to the list of allowed CORS origins in the backend configuration (backend/app/config.py). This allows browsers to correctly process responses from the backend when the frontend is accessed via the file:// protocol, resolving the communication error in the packaged Windows executable scenario.